### PR TITLE
Delay application of formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ In all projects:
   - Groovy code and Gradle files formatted for 2 space indents, trailing space removed, and newlines at the end of files.
 - ordering rules:
   - `clean` runs before everything else
-  - all `publishing` tasks run after `build` and `sonarqube`
+  - all `publishing` tasks run after `build`
 
 ### java
 

--- a/src/main/groovy/org/ajoberstar/gradle/defaults/DefaultsPlugin.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/defaults/DefaultsPlugin.groovy
@@ -203,11 +203,9 @@ class DefaultsPlugin implements Plugin<Project> {
       }
 
       def build = project.tasks['build']
-      def sonarqube = project.tasks['sonarqube']
       project.tasks.all { task ->
         if (task.group == 'publishing') {
           task.shouldRunAfter build
-          task.shouldRunAfter sonarqube
         }
       }
     }

--- a/src/main/groovy/org/ajoberstar/gradle/defaults/DefaultsPlugin.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/defaults/DefaultsPlugin.groovy
@@ -105,16 +105,20 @@ class DefaultsPlugin implements Plugin<Project> {
   private void addSpotless(Project project) {
     project.plugins.apply('com.diffplug.gradle.spotless')
     project.spotless {
-      java {
-        googleJavaFormat()
-        licenseHeaderFile project.rootProject.file('gradle/HEADER')
+      project.plugins.withId('java') {
+        java {
+          googleJavaFormat()
+          licenseHeaderFile project.rootProject.file('gradle/HEADER')
+        }
       }
-      format 'groovy', {
-        target 'src/**/*.groovy'
-        trimTrailingWhitespace()
-        indentWithSpaces(2)
-        endWithNewline()
-        licenseHeaderFile project.rootProject.file('gradle/HEADER'), 'package '
+      project.plugins.withId('groovy') {
+        format 'groovy', {
+          target 'src/**/*.groovy'
+          trimTrailingWhitespace()
+          indentWithSpaces(2)
+          endWithNewline()
+          licenseHeaderFile project.rootProject.file('gradle/HEADER'), 'package '
+        }
       }
       format 'gradle', {
         target '**/build.gradle'

--- a/src/main/groovy/org/ajoberstar/gradle/defaults/DefaultsPlugin.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/defaults/DefaultsPlugin.groovy
@@ -33,7 +33,7 @@ class DefaultsPlugin implements Plugin<Project> {
     addReleaseConfig(project)
 
     project.allprojects { prj ->
-      addSpotless(project)
+      addSpotless(prj)
       addJavaConfig(prj)
       addGroovyConfig(prj)
       addPublishingConfig(prj)


### PR DESCRIPTION
In multi-project builds you may have projects that don't
have Java or Groovy code. These shouldn't configure the java or groovy
formatters in that case, since they will just blow up.